### PR TITLE
Changed repo URI

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 
   "repository" : {
     "type": "git",
-    "url":  "git://github.com/ether/ep_copy_paste_select_all.git"
+    "url":  "git://github.com/JohnMcLear/ep_copy_paste_select_all.git"
   },
 
   "dependencies": {},


### PR DESCRIPTION
Changed repo URI to make the link from npmjs.com work. See https://www.npmjs.com/package/ep_copy_paste_select_all